### PR TITLE
Use multithreaded mode for flask.

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -12,4 +12,4 @@ def hello():
 if __name__ == '__main__':
     # Bind to PORT if defined, otherwise default to 5000.
     port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port)
+    app.run(host='0.0.0.0', port=port, threaded=True)


### PR DESCRIPTION
Multi-threaded mode should be used here, even for this very simple app.
Otherwise, if someone tests this container on e.g. AWS ECS or AWS EB
with an ELB, they will see the ELB health check keep-alive request
consume the only request thread, which will cause the container to be
killed repeatedly and the user to be deeply confused.

I lost many hours trying to debug this, figuring it was a problem with
how I had ECS/EB set up, but it was actually a nit in this example app.
